### PR TITLE
Bch download files

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Dans les propriétés du projets, remplir les champs suivants :
 
 - **Métadonnées > Identification > Titre** : Le nom de la plateforme qui sera visible par l'utilisateur (ex : Geo2France)
 - **Métadonnées > Identification > Résumé** : Facultatif, une brève présentation qui sera visible au survol
-- **Métadonnées > Liens** : Vous pouvez ajouter ici des liens vers les différents services de votre plateforme (ex : contact, catalogue, etc.) 
+- **Métadonnées > Liens** : Vous pouvez ajouter ici des liens vers les différents services de votre plateforme (ex : contact, catalogue, etc.)
    Ceux-ci seront accessibles à l'utilisateur via un clic droit sur le nom de la plateforme. Ajoutez un lien nommé `icon` pour ajouter une icône personnalisée à la plateforme (png ou svg)
 
 Pour chaque couche, vous pouvez définir :
@@ -48,7 +48,7 @@ Pour chaque couche, vous pouvez définir :
 
 Enregistrez le fichier projet (qgs ou qgz) et **déposez le sur un un serveur web** accessible depuis l'exterieur (serveur HTTP, Github, cloud, etc.).
 
-Pour proposer l'ajout d'une plateforme dans le plugin : **éditez le fichier [default_idg.json](plugin/idg/config/default_idg.json)** 
+Pour proposer l'ajout d'une plateforme dans le plugin : **éditez le fichier [default_idg.json](plugin/idg/config/default_idg.json)**
 et faites une _pull request_.
 
 ### Utilisateur

--- a/README.md
+++ b/README.md
@@ -2,11 +2,12 @@
 
 Plugin pour QGIS 3 fournissant un accès simple aux données de l'ensemble des Infrastructure de Données Géographiques (IDG) et d'autres ressources nationales géographiques utiles.
 
-Canal de discussions : https://matrix.to/#/!DqHgKIoltGIikFRreo:matrix.org
+Canal de discussions : <https://matrix.to/#/!DqHgKIoltGIikFRreo:matrix.org>
 
 ![QGIS Browser](repo/screenshot_browser_1.png)
 
 Accès aux données des plateformes :
+
 - [DataGrandEst](https://datagrandest.fr/)
 - [GéoBretagne](https://geobretagne.fr)
 - [Géo2France](https://geo2france.fr)
@@ -17,12 +18,10 @@ Accès aux données des plateformes :
 
 Pré-requis :
 
-* QGIS version LTR [3.28] ou supérieure
-* Une connexion Internet
-
-* Installation depuis le dépot QGIS : dans le gestionnaire d'exentions (Extensions > Installer/Gérer les extensions), activer les extensions expérimentales et rechercher le plugin _IDG_
-* Installation depuis le fichier zip : télécharger depuis la derniere [release](https://github.com/geo2france/idg-qgis-plugin/releases) depuis le dépot github.
-
+- QGIS version LTR [3.28] ou supérieure
+- Une connexion Internet
+- Installation depuis le dépot QGIS : dans le gestionnaire d'exentions (Extensions > Installer/Gérer les extensions), activer les extensions expérimentales et rechercher le plugin _IDG_
+- Installation depuis le fichier zip : télécharger depuis la derniere [release](https://github.com/geo2france/idg-qgis-plugin/releases) depuis le dépot github.
 
 ## Utilisation
 
@@ -31,7 +30,6 @@ Pré-requis :
 Créer un nouveau projet et y ajouter les couches que vous souhaitez diffuser.
 > **Warning**
 > Les couches doivent pouvoir être accessibles depuis n'importe où (fichiers distants, flux WMS/WFS, etc.), il ne doit **pas** s'agir de fichiers locaux.
-
 
 Il est recommandé d'[organiser les couches en groupes et sous-groupes](https://docs.qgis.org/3.22/fr/docs/user_manual/introduction/general_tools.html#group-layers-interact).
 
@@ -43,6 +41,7 @@ Dans les propriétés du projets, remplir les champs suivants :
    Ceux-ci seront accessibles à l'utilisateur via un clic droit sur le nom de la plateforme. Ajoutez un lien nommé `icon` pour ajouter une icône personnalisée à la plateforme (png ou svg)
 
 Pour chaque couche, vous pouvez définir :
+
 - **Métadonnées > Identification > Titre & Réumé** Un titre et un résumé
 - **Métadonnées > Identification > Liens** créer un lien nommé "Metadata" vers la fiche de métadonnées
 - Une symbologie (style, étiquettes, formulaires, etc.)
@@ -51,7 +50,6 @@ Enregistrez le fichier projet (qgs ou qgz) et **déposez le sur un un serveur we
 
 Pour proposer l'ajout d'une plateforme dans le plugin : **éditez le fichier [default_idg.json](plugin/idg/config/default_idg.json)** 
 et faites une _pull request_.
-
 
 ### Utilisateur
 
@@ -63,11 +61,11 @@ Depuis les paramètres du plugin, vous avez la possibilité d'afficher/masquer l
 
 ### Auteurs
 
-* Benjamin Chartier, Jean-Baptiste Desbas
+- Benjamin Chartier, Jean-Baptiste Desbas
 
 ### Source d'inspiration
 
-* Nicolas Damiens
+- Nicolas Damiens
 
 ### Contributeurs
 
@@ -75,9 +73,8 @@ Depuis les paramètres du plugin, vous avez la possibilité d'afficher/masquer l
 
 ### Autres remerciements
 
-* [Julien Moura](https://github.com/Guts) (Oslandia) pour le [template](https://oslandia.gitlab.io/qgis/template-qgis-plugin/) du plugin.
-* Auteurs des icônes de QGIS, reprises dans l'arbre des ressources
-
+- [Julien Moura](https://github.com/Guts) (Oslandia) pour le [template](https://oslandia.gitlab.io/qgis/template-qgis-plugin/) du plugin.
+- Auteurs des icônes de QGIS, reprises dans l'arbre des ressources
 
 ## Licence
 

--- a/plugin/idg/config/default_idg.json
+++ b/plugin/idg/config/default_idg.json
@@ -1,6 +1,6 @@
 {
   "Géoplateforme": "https://raw.githubusercontent.com/Geoplateforme/plugin_idg_gpf/master/projet_idg_gpf.qgz",
-  "geo2france": "https://www.geo2france.fr/public/qgis3/plugins/geo2france/geo2france.qgs",
+  "geo2france": "https://raw.githubusercontent.com/geo2france/idg-qgis-plugin-g2f/main/geo2france.qgz",
   "OPenIG": "https://raw.githubusercontent.com/openig/Plugin-QGIS3-OPenIG/master/OPenIG_qgis_plugin.qgs",
   "DataGrandEst": "https://www.datagrandest.fr/tools/plugin-qgis-datagrandest/config-plugin-idg-datagrandest.qgz",
   "GéoBretagne": "https://geobretagne.fr/pub/plugin-qgis/config-idg-geobretagne.qgs"  

--- a/plugin/idg/config/default_idg.json
+++ b/plugin/idg/config/default_idg.json
@@ -3,5 +3,5 @@
   "geo2france": "https://raw.githubusercontent.com/geo2france/idg-qgis-plugin-g2f/main/geo2france.qgz",
   "OPenIG": "https://raw.githubusercontent.com/openig/Plugin-QGIS3-OPenIG/master/OPenIG_qgis_plugin.qgs",
   "DataGrandEst": "https://www.datagrandest.fr/tools/plugin-qgis-datagrandest/config-plugin-idg-datagrandest.qgz",
-  "GéoBretagne": "https://geobretagne.fr/pub/plugin-qgis/config-idg-geobretagne.qgs"  
+  "GéoBretagne": "https://geobretagne.fr/pub/plugin-qgis/config-idg-geobretagne.qgz"  
 }

--- a/plugin/idg/gui/dlg_settings.py
+++ b/plugin/idg/gui/dlg_settings.py
@@ -146,9 +146,9 @@ class ConfigOptionsPage(FORM_CLASS, QgsOptionsPageWidget):
         items = {c.idg_id : c.url for c in RemotePlatforms(read_projects=False).plateforms if not c.is_hidden()}
         registry = QgsApplication.instance().dataItemProviderRegistry()
         provider = registry.provider(IdgProvider().name())
-        task = DownloadAllConfigFilesAsync(items) # Download non-hidden idg
-        task.finished.connect(provider.root.refresh)
-        task.start()
+        self.task = DownloadAllConfigFilesAsync(items) # Download non-hidden idg
+        self.task.finished.connect(provider.root.refresh)
+        self.task.start()
         if __debug__:
             self.log(
                 message="DEBUG - Settings successfully saved.",
@@ -176,8 +176,8 @@ class ConfigOptionsPage(FORM_CLASS, QgsOptionsPageWidget):
         # dump default settings into QgsSettings
         self.plg_settings.save_from_object(default_settings)
         self.load_settings()
-        provider = QgsApplication.dataItemProviderRegistry().provider("IDG Provider")
-        provider.root.repopulate()
+        provider = QgsApplication.instance().dataItemProviderRegistry().provider("IDG Provider")
+        provider.root.refresh()
 
 
 class PlgOptionsFactory(QgsOptionsWidgetFactory):

--- a/plugin/idg/plugin_main.py
+++ b/plugin/idg/plugin_main.py
@@ -155,28 +155,3 @@ class IdgPlugin:
 
         self.plugin_menu.addAction(self.action_settings)
         self.plugin_menu.addAction(self.action_help)
-
-    def run(self):
-        """Main process.
-
-        :raises Exception: if there is no item in the feed
-        """
-        # Jamais utilisé ?
-        try:
-            self.log(
-                message=self.tr(
-                    text="Everything ran OK.",
-                    context="IdgPlugin",
-                ),
-                log_level=3,
-                push=False,
-            )
-        except Exception as err:
-            self.log(
-                message=self.tr(
-                    text="Houston, we've got a problem: {}".format(err),
-                    context="IdgPlugin",
-                ),
-                log_level=2,
-                push=True,
-            )

--- a/plugin/idg/plugin_main.py
+++ b/plugin/idg/plugin_main.py
@@ -1,7 +1,7 @@
 #! python3  # noqa: E265
 
 """
-    Main plugin module.
+Main plugin module.
 """
 
 # PyQGIS
@@ -68,15 +68,20 @@ class IdgPlugin:
 
     def post_ui_init(self):
         """Run after plugin's UI has been initialized."""
-        items ={c.idg_id : c.url for c in RemotePlatforms(read_projects=False).plateforms if not c.is_hidden()}
+        items = {
+            c.idg_id: c.url
+            for c in RemotePlatforms(read_projects=False).plateforms
+            if not c.is_hidden()
+        }
         self.task1 = DownloadDefaultIdgListAsync()
-        self.task2 = DownloadAllConfigFilesAsync(
-            items
-        )
+        self.task2 = DownloadAllConfigFilesAsync(items)
         self.task1.finished.connect(self.task2.start)
-        self.task2.finished.connect(lambda : self.registry.addProvider(self.provider))
+        self.task2.finished.connect(lambda: self.registry.addProvider(self.provider))
 
-        self.task1.start()
+        if self.need_download_tree_config_file():
+            self.task1.start()
+        else:
+            self.task2.start()
 
     def need_download_tree_config_file(self):
         """
@@ -85,10 +90,11 @@ class IdgPlugin:
         - the user wants it to be downloading at plugin start up
         - the file is currently missing
         """
+        config_file_exists = os.path.isfile(PluginGlobals.instance().config_file_path)
 
         return (
             PluginGlobals.instance().CONFIG_FILES_DOWNLOAD_AT_STARTUP > 0
-            or not os.path.isfile(PluginGlobals.instance().config_file_path)
+            or not config_file_exists
         )
 
     def initGui(self):
@@ -123,7 +129,6 @@ class IdgPlugin:
 
         # Create a menu
         self.createPluginMenu()
-
 
     def unload(self):
         """Cleans up when plugin is disabled/uninstalled."""

--- a/plugin/idg/toolbelt/__init__.py
+++ b/plugin/idg/toolbelt/__init__.py
@@ -2,8 +2,8 @@
 from .log_handler import PlgLogger  # noqa: F401
 from .preferences import PlgOptionsManager  # noqa: F401
 from .translator import PlgTranslator  # noqa: F401
-from .plugin_globals import PluginGlobals
-from .singleton import Singleton
-from .browser import IdgProvider
-from .remote_platforms import RemotePlatforms
+from .plugin_globals import PluginGlobals  # noqa: F401
+from .singleton import Singleton  # noqa: F401
+from .browser import IdgProvider  # noqa: F401
+from .remote_platforms import RemotePlatforms  # noqa: F401
 from .network_manager import NetworkRequestsManager  # noqa: F401

--- a/plugin/idg/toolbelt/plugin_globals.py
+++ b/plugin/idg/toolbelt/plugin_globals.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 
-import sys
 import os
-import json
 from .singleton import Singleton
 from .preferences import PlgOptionsManager
 from qgis.PyQt.QtCore import QSettings
@@ -16,9 +14,14 @@ class PluginGlobals:
     plugin_path = None
     PLUGIN_TAG = "IDG"
     CONFIG_DIR_NAME = "config"
-    CONFIG_FILE_NAMES = ["projet_idg.qgs"]
+    CONFIG_FILE_NAMES = []
     CONFIG_FILES_DOWNLOAD_AT_STARTUP = PlgOptionsManager().get_value_from_key(
         "config_files_download_at_startup"
+    )
+    DEFAULT_CONFIG_FILE_NAME = "default_idg.json"
+    DEFAULT_CONFIG_FILE_URL = (
+        "https://raw.githubusercontent.com/geo2france/idg-qgis-plugin/dev/plugin/"
+        f"idg/config/{DEFAULT_CONFIG_FILE_NAME}"
     )
 
     def __init__(self):
@@ -39,13 +42,13 @@ class PluginGlobals:
         # Read the qgis plugin settings
         s = QSettings()
         self.CONFIG_FILES_DOWNLOAD_AT_STARTUP = (
-            True
+            False
             if s.value(
                 "{0}/config_files_download_at_startup".format(self.PLUGIN_TAG),
                 self.CONFIG_FILES_DOWNLOAD_AT_STARTUP,
             )
-            == "1"
-            else False
+            is False
+            else True
         )
 
         self.CONFIG_DIR_NAME = s.value(
@@ -58,5 +61,5 @@ class PluginGlobals:
 
         self.config_dir_path = os.path.join(self.plugin_path, self.CONFIG_DIR_NAME)
         self.config_file_path = os.path.join(
-            self.config_dir_path, self.CONFIG_FILE_NAMES[0]
+            self.config_dir_path, self.DEFAULT_CONFIG_FILE_NAME
         )

--- a/plugin/idg/toolbelt/preferences.py
+++ b/plugin/idg/toolbelt/preferences.py
@@ -1,19 +1,18 @@
 #! python3  # noqa: E265
 
 """
-    Plugin settings.
+Plugin settings.
 """
 
 # standard
 from dataclasses import asdict, dataclass, fields
-import json
 
 # PyQGIS
 from qgis.core import QgsSettings
 from qgis.PyQt.QtCore import QVariant
 
 # package
-import idg.toolbelt.log_handler as log_hdlr
+import idg.toolbelt
 from idg.__about__ import __title__, __version__
 
 # ############################################################################
@@ -76,7 +75,7 @@ class PlgOptionsManager:
         :return: plugin settings value matching key
         """
         if not hasattr(PlgSettingsStructure, key):
-            log_hdlr.PlgLogger.log(
+            idg.toolbelt.log_handler.PlgLogger.log(
                 message="Bad settings key. Must be one of: {}".format(
                     ",".join(PlgSettingsStructure._fields)  # A fixer
                 ),
@@ -90,7 +89,7 @@ class PlgOptionsManager:
         try:
             out_value = settings.value(key=key, defaultValue=default, type=exp_type)
         except Exception as err:
-            log_hdlr.PlgLogger.log(
+            idg.toolbelt.log_handler.PlgLogger.log(
                 message="Error occurred trying to get settings: {}.Trace: {}".format(
                     key, err
                 )
@@ -113,7 +112,7 @@ class PlgOptionsManager:
         :rtype: bool
         """
         if not hasattr(PlgSettingsStructure, key):
-            log_hdlr.PlgLogger.log(
+            idg.toolbelt.log_handler.PlgLogger.log(
                 message="Bad settings key. Must be one of: {}".format(
                     ",".join(PlgSettingsStructure._fields)
                 ),
@@ -128,7 +127,7 @@ class PlgOptionsManager:
             settings.setValue(key, value)
             out_value = True
         except Exception as err:
-            log_hdlr.PlgLogger.log(
+            idg.toolbelt.log_handler.PlgLogger.log(
                 message="Error occurred trying to set settings: {}.Trace: {}".format(
                     key, err
                 )
@@ -153,3 +152,5 @@ class PlgOptionsManager:
             cls.set_value_from_key(k, v)
 
         settings.endGroup()
+
+        idg.toolbelt.PluginGlobals.instance().reload_globals_from_qgis_settings()

--- a/plugin/idg/toolbelt/remote_platforms.py
+++ b/plugin/idg/toolbelt/remote_platforms.py
@@ -10,9 +10,7 @@ from idg.toolbelt import PlgOptionsManager, PluginGlobals
 class RemotePlatforms:
     def __init__(self, read_projects=True):
         self.plateforms = []
-        with open(
-            os.path.join(PluginGlobals.instance().config_dir_path, "default_idg.json")
-        ) as f:  # Télécharger si non existant ?
+        with open(PluginGlobals.instance().config_file_path) as f:
             self.stock_idgs = json.load(f)
         self.custom_idg = PlgOptionsManager().get_plg_settings().custom_idgs.split(",")
         self.custom_idg.remove("")
@@ -37,9 +35,7 @@ class RemotePlatforms:
 
 
 class Plateform:
-    def __init__(
-        self, url, idg_id, read_project=True
-    ):
+    def __init__(self, url, idg_id, read_project=True):
         self.url = url
         self.idg_id = idg_id
         if read_project:

--- a/plugin/idg/toolbelt/tree_node_factory.py
+++ b/plugin/idg/toolbelt/tree_node_factory.py
@@ -13,11 +13,7 @@ from .network_manager import NetworkRequestsManager
 class DownloadDefaultIdgListAsync(QThread):
     finished = pyqtSignal()
 
-    def __init__(
-        self,
-        url="https://raw.githubusercontent.com/geo2france/idg-qgis-plugin/dev/plugin/idg/config"
-        "/default_idg.json",
-    ):
+    def __init__(self, url=PluginGlobals.instance().DEFAULT_CONFIG_FILE_URL):
         super(QThread, self).__init__()
         self.url = url
 
@@ -25,7 +21,7 @@ class DownloadDefaultIdgListAsync(QThread):
         qntwk = NetworkRequestsManager()
         qntwk.download_file(
             self.url,
-            os.path.join(PluginGlobals.instance().config_dir_path, "default_idg.json"),
+            os.path.join(PluginGlobals.instance().config_file_path),
         )
         self.finished.emit()
 


### PR DESCRIPTION
Pull request associée à #71 :
- définition à un seul endroit du nom du fichier de config par défaut
- création d'une constante pour stocker l'URL de ce fichier de config
- rechargement de `PluginGlobals` quand les settings sont modifiés (ce n'était pas fait)
- correction de la lecture du paramètre `config_files_download_at_startup`
- chargement du fichier de config que s'il n'est pas présent dans l'arborescence du plugin ou si le paramètre `config_files_download_at_startup` du plugin est à True ou None.