### PR TITLE
 Téléchargement du fichier de config par défaut uniquement si besoin …

### DIFF
--- a/plugin/idg/gui/dlg_settings.py
+++ b/plugin/idg/gui/dlg_settings.py
@@ -1,7 +1,7 @@
 #! python3  # noqa: E265
 
 """
-    Plugin settings form integrated into QGIS 'Options' menu.
+Plugin settings form integrated into QGIS 'Options' menu.
 """
 
 # standard
@@ -27,9 +27,15 @@ from idg.__about__ import (
     __uri_tracker__,
     __version__,
 )
-from idg.toolbelt import PlgLogger, PlgOptionsManager, PluginGlobals, RemotePlatforms, IdgProvider
+from idg.toolbelt import (
+    PlgLogger,
+    PlgOptionsManager,
+    PluginGlobals,
+    RemotePlatforms,
+    IdgProvider,
+)
 from idg.toolbelt.preferences import PlgSettingsStructure
-from idg.toolbelt.tree_node_factory import DownloadAllConfigFilesAsync
+from idg.toolbelt.tree_node_factory import DownloadAllIdgFilesAsync
 
 # ############################################################################
 # ########## Globals ###############
@@ -143,10 +149,14 @@ class ConfigOptionsPage(FORM_CLASS, QgsOptionsPageWidget):
             settings
         )  # Les variables globales ne sont peut être pas MAJ ici
 
-        items = {c.idg_id : c.url for c in RemotePlatforms(read_projects=False).plateforms if not c.is_hidden()}
+        items = {
+            c.idg_id: c.url
+            for c in RemotePlatforms(read_projects=False).plateforms
+            if not c.is_hidden()
+        }
         registry = QgsApplication.instance().dataItemProviderRegistry()
         provider = registry.provider(IdgProvider().name())
-        self.task = DownloadAllConfigFilesAsync(items) # Download non-hidden idg
+        self.task = DownloadAllIdgFilesAsync(items)  # Download non-hidden idg
         self.task.finished.connect(provider.root.refresh)
         self.task.start()
         if __debug__:
@@ -176,7 +186,11 @@ class ConfigOptionsPage(FORM_CLASS, QgsOptionsPageWidget):
         # dump default settings into QgsSettings
         self.plg_settings.save_from_object(default_settings)
         self.load_settings()
-        provider = QgsApplication.instance().dataItemProviderRegistry().provider("IDG Provider")
+        provider = (
+            QgsApplication.instance()
+            .dataItemProviderRegistry()
+            .provider("IDG Provider")
+        )
         provider.root.refresh()
 
 

--- a/plugin/idg/plugin_main.py
+++ b/plugin/idg/plugin_main.py
@@ -1,7 +1,7 @@
 #! python3  # noqa: E265
 
 """
-    Main plugin module.
+Main plugin module.
 """
 
 # PyQGIS
@@ -68,15 +68,20 @@ class IdgPlugin:
 
     def post_ui_init(self):
         """Run after plugin's UI has been initialized."""
-        items ={c.idg_id : c.url for c in RemotePlatforms(read_projects=False).plateforms if not c.is_hidden()}
+        items = {
+            c.idg_id: c.url
+            for c in RemotePlatforms(read_projects=False).plateforms
+            if not c.is_hidden()
+        }
         self.task1 = DownloadDefaultIdgListAsync()
-        self.task2 = DownloadAllConfigFilesAsync(
-            items
-        )
+        self.task2 = DownloadAllConfigFilesAsync(items)
         self.task1.finished.connect(self.task2.start)
-        self.task2.finished.connect(lambda : self.registry.addProvider(self.provider))
+        self.task2.finished.connect(lambda: self.registry.addProvider(self.provider))
 
-        self.task1.start()
+        if self.need_download_tree_config_file():
+            self.task1.start()
+        else:
+            self.task2.start()
 
     def need_download_tree_config_file(self):
         """
@@ -85,10 +90,11 @@ class IdgPlugin:
         - the user wants it to be downloading at plugin start up
         - the file is currently missing
         """
+        config_file_exists = os.path.isfile(PluginGlobals.instance().config_file_path)
 
         return (
             PluginGlobals.instance().CONFIG_FILES_DOWNLOAD_AT_STARTUP > 0
-            or not os.path.isfile(PluginGlobals.instance().config_file_path)
+            or not config_file_exists
         )
 
     def initGui(self):
@@ -123,7 +129,6 @@ class IdgPlugin:
 
         # Create a menu
         self.createPluginMenu()
-
 
     def unload(self):
         """Cleans up when plugin is disabled/uninstalled."""

--- a/plugin/idg/plugin_main.py
+++ b/plugin/idg/plugin_main.py
@@ -22,7 +22,7 @@ from idg.toolbelt import PlgLogger, PlgTranslator
 from idg.toolbelt import PluginGlobals, IdgProvider
 from idg.toolbelt.remote_platforms import RemotePlatforms
 from idg.toolbelt.tree_node_factory import (
-    DownloadAllConfigFilesAsync,
+    DownloadAllIdgFilesAsync,
     DownloadDefaultIdgListAsync,
 )
 
@@ -74,14 +74,12 @@ class IdgPlugin:
             if not c.is_hidden()
         }
         self.task1 = DownloadDefaultIdgListAsync()
-        self.task2 = DownloadAllConfigFilesAsync(items)
+        self.task2 = DownloadAllIdgFilesAsync(items)
         self.task1.finished.connect(self.task2.start)
         self.task2.finished.connect(lambda: self.registry.addProvider(self.provider))
 
         if self.need_download_tree_config_file():
             self.task1.start()
-        else:
-            self.task2.start()
 
     def need_download_tree_config_file(self):
         """
@@ -93,7 +91,7 @@ class IdgPlugin:
         config_file_exists = os.path.isfile(PluginGlobals.instance().config_file_path)
 
         return (
-            PluginGlobals.instance().CONFIG_FILES_DOWNLOAD_AT_STARTUP > 0
+            PluginGlobals.instance().DOWNLOAD_FILES_AT_STARTUP > 0
             or not config_file_exists
         )
 

--- a/plugin/idg/toolbelt/plugin_globals.py
+++ b/plugin/idg/toolbelt/plugin_globals.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 
-import sys
 import os
-import json
 from .singleton import Singleton
 from .preferences import PlgOptionsManager
 from qgis.PyQt.QtCore import QSettings
@@ -16,9 +14,14 @@ class PluginGlobals:
     plugin_path = None
     PLUGIN_TAG = "IDG"
     CONFIG_DIR_NAME = "config"
-    CONFIG_FILE_NAMES = ["projet_idg.qgs"]
+    CONFIG_FILE_NAMES = []
     CONFIG_FILES_DOWNLOAD_AT_STARTUP = PlgOptionsManager().get_value_from_key(
         "config_files_download_at_startup"
+    )
+    DEFAULT_CONFIG_FILE_NAME = "default_idg.json"
+    DEFAULT_CONFIG_FILE_URL = (
+        "https://raw.githubusercontent.com/geo2france/idg-qgis-plugin/dev/plugin/"
+        f"idg/config/{DEFAULT_CONFIG_FILE_NAME}"
     )
 
     def __init__(self):
@@ -39,13 +42,13 @@ class PluginGlobals:
         # Read the qgis plugin settings
         s = QSettings()
         self.CONFIG_FILES_DOWNLOAD_AT_STARTUP = (
-            True
+            False
             if s.value(
                 "{0}/config_files_download_at_startup".format(self.PLUGIN_TAG),
                 self.CONFIG_FILES_DOWNLOAD_AT_STARTUP,
             )
-            == "1"
-            else False
+            is False
+            else True
         )
 
         self.CONFIG_DIR_NAME = s.value(
@@ -58,5 +61,5 @@ class PluginGlobals:
 
         self.config_dir_path = os.path.join(self.plugin_path, self.CONFIG_DIR_NAME)
         self.config_file_path = os.path.join(
-            self.config_dir_path, self.CONFIG_FILE_NAMES[0]
+            self.config_dir_path, self.DEFAULT_CONFIG_FILE_NAME
         )

--- a/plugin/idg/toolbelt/plugin_globals.py
+++ b/plugin/idg/toolbelt/plugin_globals.py
@@ -15,8 +15,8 @@ class PluginGlobals:
     PLUGIN_TAG = "IDG"
     CONFIG_DIR_NAME = "config"
     CONFIG_FILE_NAMES = []
-    CONFIG_FILES_DOWNLOAD_AT_STARTUP = PlgOptionsManager().get_value_from_key(
-        "config_files_download_at_startup"
+    DOWNLOAD_FILES_AT_STARTUP = PlgOptionsManager().get_value_from_key(
+        "download_files_at_startup"
     )
     DEFAULT_CONFIG_FILE_NAME = "default_idg.json"
     DEFAULT_CONFIG_FILE_URL = (
@@ -41,11 +41,11 @@ class PluginGlobals:
 
         # Read the qgis plugin settings
         s = QSettings()
-        self.CONFIG_FILES_DOWNLOAD_AT_STARTUP = (
+        self.DOWNLOAD_FILES_AT_STARTUP = (
             False
             if s.value(
-                "{0}/config_files_download_at_startup".format(self.PLUGIN_TAG),
-                self.CONFIG_FILES_DOWNLOAD_AT_STARTUP,
+                "{0}/download_files_at_startup".format(self.PLUGIN_TAG),
+                self.DOWNLOAD_FILES_AT_STARTUP,
             )
             is False
             else True

--- a/plugin/idg/toolbelt/preferences.py
+++ b/plugin/idg/toolbelt/preferences.py
@@ -1,19 +1,18 @@
 #! python3  # noqa: E265
 
 """
-    Plugin settings.
+Plugin settings.
 """
 
 # standard
 from dataclasses import asdict, dataclass, fields
-import json
 
 # PyQGIS
 from qgis.core import QgsSettings
 from qgis.PyQt.QtCore import QVariant
 
 # package
-import idg.toolbelt.log_handler as log_hdlr
+import idg.toolbelt
 from idg.__about__ import __title__, __version__
 
 # ############################################################################
@@ -76,7 +75,7 @@ class PlgOptionsManager:
         :return: plugin settings value matching key
         """
         if not hasattr(PlgSettingsStructure, key):
-            log_hdlr.PlgLogger.log(
+            idg.toolbelt.log_handler.PlgLogger.log(
                 message="Bad settings key. Must be one of: {}".format(
                     ",".join(PlgSettingsStructure._fields)  # A fixer
                 ),
@@ -90,7 +89,7 @@ class PlgOptionsManager:
         try:
             out_value = settings.value(key=key, defaultValue=default, type=exp_type)
         except Exception as err:
-            log_hdlr.PlgLogger.log(
+            idg.toolbelt.log_handler.PlgLogger.log(
                 message="Error occurred trying to get settings: {}.Trace: {}".format(
                     key, err
                 )
@@ -113,7 +112,7 @@ class PlgOptionsManager:
         :rtype: bool
         """
         if not hasattr(PlgSettingsStructure, key):
-            log_hdlr.PlgLogger.log(
+            idg.toolbelt.log_handler.PlgLogger.log(
                 message="Bad settings key. Must be one of: {}".format(
                     ",".join(PlgSettingsStructure._fields)
                 ),
@@ -128,7 +127,7 @@ class PlgOptionsManager:
             settings.setValue(key, value)
             out_value = True
         except Exception as err:
-            log_hdlr.PlgLogger.log(
+            idg.toolbelt.log_handler.PlgLogger.log(
                 message="Error occurred trying to set settings: {}.Trace: {}".format(
                     key, err
                 )
@@ -153,3 +152,5 @@ class PlgOptionsManager:
             cls.set_value_from_key(k, v)
 
         settings.endGroup()
+
+        idg.toolbelt.PluginGlobals.instance().reload_globals_from_qgis_settings()

--- a/plugin/idg/toolbelt/preferences.py
+++ b/plugin/idg/toolbelt/preferences.py
@@ -28,7 +28,7 @@ class PlgSettingsStructure:
     debug_mode: bool = False
     version: str = __version__
     configs_folder: str = ""
-    config_files_download_at_startup: bool = False
+    download_files_at_startup: bool = True
     hide_empty_groups: bool = True
     hide_resources_with_warn_status: bool = True
     custom_idgs: str = ""

--- a/plugin/idg/toolbelt/remote_platforms.py
+++ b/plugin/idg/toolbelt/remote_platforms.py
@@ -10,9 +10,7 @@ from idg.toolbelt import PlgOptionsManager, PluginGlobals
 class RemotePlatforms:
     def __init__(self, read_projects=True):
         self.plateforms = []
-        with open(
-            os.path.join(PluginGlobals.instance().config_dir_path, "default_idg.json")
-        ) as f:  # Télécharger si non existant ?
+        with open(PluginGlobals.instance().config_file_path) as f:
             self.stock_idgs = json.load(f)
         self.custom_idg = PlgOptionsManager().get_plg_settings().custom_idgs.split(",")
         self.custom_idg.remove("")
@@ -37,9 +35,7 @@ class RemotePlatforms:
 
 
 class Plateform:
-    def __init__(
-        self, url, idg_id, read_project=True
-    ):
+    def __init__(self, url, idg_id, read_project=True):
         self.url = url
         self.idg_id = idg_id
         if read_project:

--- a/plugin/idg/toolbelt/tree_node_factory.py
+++ b/plugin/idg/toolbelt/tree_node_factory.py
@@ -26,7 +26,7 @@ class DownloadDefaultIdgListAsync(QThread):
         self.finished.emit()
 
 
-class DownloadAllConfigFilesAsync(QThread):
+class DownloadAllIdgFilesAsync(QThread):
     finished = pyqtSignal()
 
     def __init__(self, idgs):

--- a/plugin/idg/toolbelt/tree_node_factory.py
+++ b/plugin/idg/toolbelt/tree_node_factory.py
@@ -13,11 +13,7 @@ from .network_manager import NetworkRequestsManager
 class DownloadDefaultIdgListAsync(QThread):
     finished = pyqtSignal()
 
-    def __init__(
-        self,
-        url="https://raw.githubusercontent.com/geo2france/idg-qgis-plugin/dev/plugin/idg/config"
-        "/default_idg.json",
-    ):
+    def __init__(self, url=PluginGlobals.instance().DEFAULT_CONFIG_FILE_URL):
         super(QThread, self).__init__()
         self.url = url
 
@@ -25,7 +21,7 @@ class DownloadDefaultIdgListAsync(QThread):
         qntwk = NetworkRequestsManager()
         qntwk.download_file(
             self.url,
-            os.path.join(PluginGlobals.instance().config_dir_path, "default_idg.json"),
+            os.path.join(PluginGlobals.instance().config_file_path),
         )
         self.finished.emit()
 


### PR DESCRIPTION
Pull request associée à #71 :

- définition à un seul endroit du nom du fichier de config par défaut
- création d'une constante pour stocker l'URL de ce fichier de config
- rechargement de `PluginGlobals` quand les settings sont modifiés (ce n'était pas fait)
- correction de la lecture du paramètre `config_files_download_at_startup`
- chargement du fichier de config que s'il n'est pas présent dans l'arborescence du plugin ou si le paramètre `config_files_download_at_startup` du plugin est à `True` ou `None`.