### PR TITLE
optimzation : do not read hidden plateforms

### DIFF
--- a/idg/browser/browser.py
+++ b/idg/browser/browser.py
@@ -106,7 +106,7 @@ class RootCollection(QgsDataCollectionItem):
         children = []
         for pfc in [
             PlatformCollection(plateform=pf, parent=self)
-            for pf in RemotePlatforms().plateforms
+            for pf in RemotePlatforms(read_projects=False).plateforms
             if not pf.is_hidden()
         ]:
             children.append(pfc)
@@ -115,6 +115,8 @@ class RootCollection(QgsDataCollectionItem):
 
 class PlatformCollection(QgsDataCollectionItem):
     def __init__(self, plateform, parent):
+        if plateform.project is None :
+            plateform.read_project()
         self.url = plateform.url
         self.path = "/IDG/" + plateform.idg_id.lower()
         self.parent = parent

--- a/idg/browser/remote_platforms.py
+++ b/idg/browser/remote_platforms.py
@@ -52,8 +52,9 @@ class Plateform:
     def __init__(self, url, idg_id, read_project=True):
         self.url = url
         self.idg_id = idg_id
+        self.project = None
         if read_project:
-            self.project = self.read_project()
+            self.read_project()
 
     def read_project(self):
         p = QgsProject()
@@ -67,6 +68,7 @@ class Plateform:
             is not True
         ):  # Le flag permet d'éviter que les URL des layers soient interrogées, mais le datasource du layer doit être reset avant usage
             return None
+        self.project = p
         return p
 
     def qgis_project_filepath(self):


### PR DESCRIPTION
Améliore significativement les performances en ne lisant PAS les fichiers projets des plateformes masquées.
Cf #103 